### PR TITLE
With namespace and name transform

### DIFF
--- a/src/components/Compiler/Compiler.ts
+++ b/src/components/Compiler/Compiler.ts
@@ -10,7 +10,11 @@ import { BaseCompiler } from "./base/BaseCompiler";
 export class Compiler extends BaseCompiler {
     public exports: ExportModel[];
 
-    public constructor(outputDir: string, public logicalTypes?: { [key: string]: string }) {
+    public constructor(
+        outputDir: string,
+        public logicalTypes?: { [key: string]: string},
+        public transformName?: (input: string) => string,
+    ) {
         super();
 
         this.classPath = path.resolve(outputDir);
@@ -38,7 +42,7 @@ export class Compiler extends BaseCompiler {
     }
 
     public async compile(data: any): Promise<CompilerOutput> {
-        const classConverter = new ClassConverter(this.logicalTypes);
+        const classConverter = new ClassConverter(this.logicalTypes, this.transformName);
         data = classConverter.getData(data);
 
         const namespace = data.namespace.replace(/\./g, path.sep);

--- a/src/components/Compiler/Compiler.ts
+++ b/src/components/Compiler/Compiler.ts
@@ -4,20 +4,28 @@ import { DirHelper } from "../../helpers/DirHelper";
 import { TypeHelper } from "../../helpers/TypeHelper";
 import { CompilerOutput } from "../../interfaces/CompilerOutput";
 import { ExportModel } from "../../models/ExportModel";
+import { CompilerConfig } from "../Compiler/base/BaseCompiler";
 import { ClassConverter } from "../Converters/ClassConverter";
 import { BaseCompiler } from "./base/BaseCompiler";
 
 export class Compiler extends BaseCompiler {
     public exports: ExportModel[];
+    public logicalTypesMap: {[key: string]: string } = {};
+    public transformName?: (input: string) => string;
 
     public constructor(
         outputDir: string,
-        public logicalTypes?: { [key: string]: string},
-        public transformName?: (input: string) => string,
+        config?: CompilerConfig,
     ) {
         super();
 
         this.classPath = path.resolve(outputDir);
+        if (config) {
+            this.transformName = config.transformName;
+            if (config.logicalTypes) {
+                this.logicalTypesMap = config.logicalTypes;
+            }
+        }
     }
 
     public async compileFolder(schemaPath: string): Promise<void> {
@@ -42,7 +50,10 @@ export class Compiler extends BaseCompiler {
     }
 
     public async compile(data: any): Promise<CompilerOutput> {
-        const classConverter = new ClassConverter(this.logicalTypes, this.transformName);
+        const classConverter = new ClassConverter({
+            logicalTypes: this.logicalTypesMap,
+            transformName: this.transformName,
+        });
         data = classConverter.getData(data);
 
         const namespace = data.namespace.replace(/\./g, path.sep);

--- a/src/components/Compiler/base/BaseCompiler.ts
+++ b/src/components/Compiler/base/BaseCompiler.ts
@@ -1,3 +1,8 @@
+export interface CompilerConfig {
+    logicalTypes?: { [key: string]: string};
+    transformName?: (input: string) => string;
+}
+
 export abstract class BaseCompiler {
     private _schemaPath: string;
     private _classPath: string;

--- a/src/components/Converters/ClassConverter.ts
+++ b/src/components/Converters/ClassConverter.ts
@@ -67,20 +67,20 @@ export class ClassConverter extends RecordConverter {
         const interfaceRows: string[] = [];
         const TAB = SpecialCharacterHelper.TAB;
 
-        let name = data.name;
-        if (data.namespace) { name = `${data.namespace}.${name}`; }
-        if (typeof this.transformName === "function") { name = this.transformName(name); }
+        let fullName = data.name;
+        if (data.namespace) { fullName = `${data.namespace}.${fullName}`; }
+        if (typeof this.transformName === "function") { fullName = this.transformName(fullName); }
 
-        interfaceRows.push(`export interface ${name}${this.interfaceSuffix} {`);
-        rows.push(`export class ${name} extends BaseAvroRecord implements ${name}${this.interfaceSuffix} {`);
+        interfaceRows.push(`export interface ${fullName}${this.interfaceSuffix} {`);
+        rows.push(`export class ${fullName} extends BaseAvroRecord implements ${fullName}${this.interfaceSuffix} {`);
         rows.push(``);
 
-        rows.push(`${TAB}public static readonly subject: string = "${name}";`);
+        rows.push(`${TAB}public static readonly subject: string = "${fullName}";`);
         rows.push(`${TAB}public static readonly schema: object = ${JSON.stringify(data, null, 4)}`);
         rows.push(``);
 
-        rows.push(`${TAB}public static deserialize(buffer: Buffer, newSchema?: object): ${name} {`);
-        rows.push(`${TAB}${TAB}const result = new ${name}();`);
+        rows.push(`${TAB}public static deserialize(buffer: Buffer, newSchema?: object): ${fullName} {`);
+        rows.push(`${TAB}${TAB}const result = new ${fullName}();`);
         rows.push(`${TAB}${TAB}const rawResult = this.internalDeserialize(buffer, newSchema);`);
         rows.push(`${TAB}${TAB}result.loadValuesFromType(rawResult);`);
         rows.push(``);
@@ -91,16 +91,16 @@ export class ClassConverter extends RecordConverter {
         for (const field of data.fields) {
             let fieldType;
             let classRow;
-            let fieldName = field.name;
-            if (typeof this.transformName === "function") { fieldName = this.transformName(fieldName); }
+            let fullFieldName = field.name;
+            if (typeof this.transformName === "function") { fullFieldName = this.transformName(fullFieldName); }
             if (TypeHelper.hasDefault(field) || TypeHelper.isOptional(field.type)) {
                 const defaultValue = TypeHelper.hasDefault(field) ? ` = ${TypeHelper.getDefault(field)}` : "";
-                fieldType = `${this.getField(field, fieldName)}`;
+                fieldType = `${this.getField(field, fullFieldName)}`;
                 classRow = `${TAB}public ${fieldType}${defaultValue};`;
             } else {
                 const convertedType = this.convertType(field.type);
-                fieldType = `${fieldName}: ${convertedType}`;
-                classRow = `${TAB}public ${fieldName}!: ${convertedType};`;
+                fieldType = `${fullFieldName}: ${convertedType}`;
+                classRow = `${TAB}public ${fullFieldName}!: ${convertedType};`;
             }
 
             interfaceRows.push(`${this.TAB}${fieldType};`);
@@ -112,13 +112,13 @@ export class ClassConverter extends RecordConverter {
         rows.push(``);
 
         rows.push(`${TAB}public schema(): object {`);
-        rows.push(`${TAB}${TAB}return ${name}.schema;`);
+        rows.push(`${TAB}${TAB}return ${fullName}.schema;`);
         rows.push(`${TAB}}`);
 
         rows.push(``);
 
         rows.push(`${TAB}public subject(): string {`);
-        rows.push(`${TAB}${TAB}return ${name}.subject;`);
+        rows.push(`${TAB}${TAB}return ${fullName}.subject;`);
         rows.push(`${TAB}}`);
 
         rows.push(`}`);

--- a/src/components/Converters/RecordConverter.ts
+++ b/src/components/Converters/RecordConverter.ts
@@ -14,20 +14,24 @@ export class RecordConverter extends BaseConverter {
     public convert(data: any): ExportModel {
         data = this.getData(data) as RecordType;
 
-        this.interfaceRows.push(...this.extractInterface(data));
+        let name = data.name;
+        if (data.namespace) { name = `${data.namespace}.${name}`; }
+        if (typeof this.transformName === "function") { name = this.transformName(name); }
+
+        this.interfaceRows.push(...this.extractInterface(data, name));
 
         const exportModel = new ExportModel();
-        exportModel.name = data.name;
+        exportModel.name = name;
         exportModel.content = this.interfaceRows.join(SpecialCharacterHelper.NEW_LINE);
         this.exports.push(exportModel);
 
         return exportModel;
     }
 
-    protected extractInterface(data: RecordType): string[] {
+    protected extractInterface(data: RecordType, name?: string): string[] {
         const rows: string[] = [];
 
-        rows.push(`export interface ${data.name} {`);
+        rows.push(`export interface ${name || data.name} {`);
 
         for (const field of data.fields) {
             const fieldType = `${this.getField(field)};`;
@@ -84,7 +88,7 @@ export class RecordConverter extends BaseConverter {
         return "any";
     }
 
-    protected getField(field: Field): string {
-        return `${field.name}${TypeHelper.isOptional(field.type) ? "?" : ""}: ${this.convertType(field.type)}`;
+    protected getField(field: Field, fieldName?: string): string {
+        return `${fieldName || field.name}${TypeHelper.isOptional(field.type) ? "?" : ""}: ${this.convertType(field.type)}`;
     }
 }

--- a/src/components/Converters/RecordConverter.ts
+++ b/src/components/Converters/RecordConverter.ts
@@ -14,24 +14,24 @@ export class RecordConverter extends BaseConverter {
     public convert(data: any): ExportModel {
         data = this.getData(data) as RecordType;
 
-        let name = data.name;
-        if (data.namespace) { name = `${data.namespace}.${name}`; }
-        if (typeof this.transformName === "function") { name = this.transformName(name); }
+        let fullName = data.name;
+        if (data.namespace) { fullName = `${data.namespace}.${fullName}`; }
+        if (typeof this.transformName === "function") { fullName = this.transformName(fullName); }
 
-        this.interfaceRows.push(...this.extractInterface(data, name));
+        this.interfaceRows.push(...this.extractInterface(data, fullName));
 
         const exportModel = new ExportModel();
-        exportModel.name = name;
+        exportModel.name = fullName;
         exportModel.content = this.interfaceRows.join(SpecialCharacterHelper.NEW_LINE);
         this.exports.push(exportModel);
 
         return exportModel;
     }
 
-    protected extractInterface(data: RecordType, name?: string): string[] {
+    protected extractInterface(data: RecordType, transformedName?: string): string[] {
         const rows: string[] = [];
 
-        rows.push(`export interface ${name || data.name} {`);
+        rows.push(`export interface ${transformedName || data.name} {`);
 
         for (const field of data.fields) {
             const fieldType = `${this.getField(field)};`;
@@ -88,7 +88,7 @@ export class RecordConverter extends BaseConverter {
         return "any";
     }
 
-    protected getField(field: Field, fieldName?: string): string {
-        return `${fieldName || field.name}${TypeHelper.isOptional(field.type) ? "?" : ""}: ${this.convertType(field.type)}`;
+    protected getField(field: Field, transformedFieldName?: string): string {
+        return `${transformedFieldName || field.name}${TypeHelper.isOptional(field.type) ? "?" : ""}: ${this.convertType(field.type)}`;
     }
 }

--- a/src/components/Converters/base/BaseConverter.ts
+++ b/src/components/Converters/base/BaseConverter.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import { SpecialCharacterHelper } from "../../../helpers/SpecialCharacterHelper";
 import { AvroSchema } from "../../../interfaces/AvroSchema";
 import { ExportModel } from "../../../models/ExportModel";
+import { CompilerConfig } from "../../Compiler/base/BaseCompiler";
 
 export abstract class BaseConverter {
     public static errorMessages = {
@@ -15,11 +16,17 @@ export abstract class BaseConverter {
     public exports: ExportModel[] = [];
     public enumExports: ExportModel[] = [];
     public interfaceExports: ExportModel[] = [];
+    public logicalTypesMap: {[key: string]: string } = {};
+    public transformName?: (input: string) => string;
 
-    constructor(
-        public logicalTypesMap: {[key: string]: string } = {},
-        public transformName?: (input: string) => string,
-    ) {}
+    constructor(config?: CompilerConfig) {
+        if (config) {
+            this.transformName = config.transformName;
+            if (config.logicalTypes) {
+                this.logicalTypesMap = config.logicalTypes;
+            }
+        }
+    }
 
     public abstract convert(data: any): any;
 

--- a/src/components/Converters/base/BaseConverter.ts
+++ b/src/components/Converters/base/BaseConverter.ts
@@ -16,7 +16,10 @@ export abstract class BaseConverter {
     public enumExports: ExportModel[] = [];
     public interfaceExports: ExportModel[] = [];
 
-    constructor(public logicalTypesMap: { [key: string]: string } = {}) {}
+    constructor(
+        public logicalTypesMap: {[key: string]: string } = {},
+        public transformName?: (input: string) => string,
+    ) {}
 
     public abstract convert(data: any): any;
 
@@ -32,7 +35,7 @@ export abstract class BaseConverter {
 
                 exports.push(nextExport.content);
 
-                return `${exports.join(`${SpecialCharacterHelper.NEW_LINE}${SpecialCharacterHelper.NEW_LINE}`)}`;
+                return exports.join(`${SpecialCharacterHelper.NEW_LINE}${SpecialCharacterHelper.NEW_LINE}`);
             }, "");
         result += `${SpecialCharacterHelper.NEW_LINE}`;
 

--- a/test/components/Compiler.ts
+++ b/test/components/Compiler.ts
@@ -12,6 +12,13 @@ const avroFolder = path.resolve(dataFolder + `/avro/`);
 const expectedFolder = path.resolve(dataFolder + `/expected/`);
 const compiledFolder = path.resolve(dataFolder + `/compiled/`);
 
+const toCamelCase = (name: string) => {
+    return name.replace(
+        /(\w)\.(\w)/gu,
+        (match, p1: string, p2: string) => `${p1}${p2.toUpperCase()}`,
+    );
+};
+
 describe("Testing Compiler", () => {
 
     afterEach(() => {
@@ -25,7 +32,7 @@ describe("Testing Compiler", () => {
         const compiledFile = `${compiledFolder}/com/example/avro/User.ts`;
         const expectedFile = `${expectedFolder}/User.ts.test`;
 
-        const compiler = new Compiler(compiledFolder, {}, (str) => str.replace(/\./gu, ""));
+        const compiler = new Compiler(compiledFolder, {transformName: toCamelCase});
 
         await compiler.compile(avro);
 
@@ -40,7 +47,7 @@ describe("Testing Compiler", () => {
         const compiledFile = `${compiledFolder}/com/example/avro/TradeCollection.ts`;
         const expectedFile = `${expectedFolder}/TradeCollection.ts.test`;
 
-        const compiler = new Compiler(compiledFolder, {}, (str) => str.replace(/\./gu, ""));
+        const compiler = new Compiler(compiledFolder, {transformName: toCamelCase});
 
         await compiler.compile(avro);
 
@@ -55,7 +62,7 @@ describe("Testing Compiler", () => {
         const compiledFile = `${compiledFolder}/BaseAvroRecord.ts`;
         const expectedFile = `${expectedFolder}/BaseAvroRecord.ts.test`;
 
-        const compiler = new Compiler(compiledFolder, {}, (str) => str.replace(/\./gu, ""));
+        const compiler = new Compiler(compiledFolder, {transformName: toCamelCase});
 
         await compiler.compile(avro);
 

--- a/test/components/Compiler.ts
+++ b/test/components/Compiler.ts
@@ -25,7 +25,7 @@ describe("Testing Compiler", () => {
         const compiledFile = `${compiledFolder}/com/example/avro/User.ts`;
         const expectedFile = `${expectedFolder}/User.ts.test`;
 
-        const compiler = new Compiler(compiledFolder);
+        const compiler = new Compiler(compiledFolder, {}, (str) => str.replace(/\./gu, ""));
 
         await compiler.compile(avro);
 
@@ -40,7 +40,7 @@ describe("Testing Compiler", () => {
         const compiledFile = `${compiledFolder}/com/example/avro/TradeCollection.ts`;
         const expectedFile = `${expectedFolder}/TradeCollection.ts.test`;
 
-        const compiler = new Compiler(compiledFolder);
+        const compiler = new Compiler(compiledFolder, {}, (str) => str.replace(/\./gu, ""));
 
         await compiler.compile(avro);
 
@@ -55,7 +55,7 @@ describe("Testing Compiler", () => {
         const compiledFile = `${compiledFolder}/BaseAvroRecord.ts`;
         const expectedFile = `${expectedFolder}/BaseAvroRecord.ts.test`;
 
-        const compiler = new Compiler(compiledFolder);
+        const compiler = new Compiler(compiledFolder, {}, (str) => str.replace(/\./gu, ""));
 
         await compiler.compile(avro);
 

--- a/test/components/Converters/ClassConverter.ts
+++ b/test/components/Converters/ClassConverter.ts
@@ -15,9 +15,18 @@ const getExpectedResult = (file: string) => {
     return fs.readFileSync(file).toString();
 };
 
+const toCamelCase = (name: string) => {
+    return name.replace(
+        /(\w)\.(\w)/gu,
+        (match, p1: string, p2: string) => `${p1}${p2.toUpperCase()}`,
+    );
+};
+
 describe("RecordType Converter test", () => {
     it("should convert User avro schema to TS class", () => {
-        const converter = new ClassConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new ClassConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/User.avsc`);
 
         const actual = converter.joinExports();
@@ -26,7 +35,9 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert TradeCollection avro schema to TS class", () => {
-        const converter = new ClassConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new ClassConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/TradeCollection.avsc`);
 
         const actual = converter.joinExports();

--- a/test/components/Converters/ClassConverter.ts
+++ b/test/components/Converters/ClassConverter.ts
@@ -17,7 +17,7 @@ const getExpectedResult = (file: string) => {
 
 describe("RecordType Converter test", () => {
     it("should convert User avro schema to TS class", () => {
-        const converter = new ClassConverter();
+        const converter = new ClassConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/User.avsc`);
 
         const actual = converter.joinExports();
@@ -26,7 +26,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert TradeCollection avro schema to TS class", () => {
-        const converter = new ClassConverter();
+        const converter = new ClassConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/TradeCollection.avsc`);
 
         const actual = converter.joinExports();

--- a/test/components/Converters/RecordConverter.ts
+++ b/test/components/Converters/RecordConverter.ts
@@ -15,9 +15,18 @@ const getExpectedResult = (file: string) => {
     return fs.readFileSync(file).toString();
 };
 
+const toCamelCase = (name: string) => {
+    return name.replace(
+        /(\w)\.(\w)/gu,
+        (match, p1: string, p2: string) => `${p1}${p2.toUpperCase()}`,
+    );
+};
+
 describe("RecordType Converter test", () => {
     it("should convert simple avro schema to TS interface", () => {
-        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/SimpleRecord.avsc`);
 
         const actual = converter.joinExports();
@@ -26,7 +35,9 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert simple avro schema json to TS interface", () => {
-        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            transformName: toCamelCase,
+        });
         const avro = JSON.parse(fs.readFileSync(`${avroFolder}/SimpleRecord.json`).toString());
         converter.convert(avro);
 
@@ -36,7 +47,9 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with interface to TS interface", () => {
-        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/RecordWithInterface.avsc`);
 
         const actual = converter.joinExports();
@@ -45,7 +58,9 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with MapType type to TS interface", () => {
-        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/RecordWithMap.avsc`);
 
         const actual = converter.joinExports();
@@ -54,7 +69,9 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with all types to TS interface", () => {
-        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/RecordWithUnion.avsc`);
 
         const actual = converter.joinExports();
@@ -63,7 +80,9 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with logical types", () => {
-        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/RecordWithLogicalTypes.avsc`);
 
         const actual = converter.joinExports();
@@ -72,7 +91,10 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with mapped logical types", () => {
-        const converter = new RecordConverter({ "timestamp-millis" : "string" }, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            logicalTypes: { "timestamp-millis" : "string" },
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/RecordWithLogicalTypes.avsc`);
 
         const actual = converter.joinExports();
@@ -81,7 +103,9 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with MapType type to TS interface", () => {
-        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
+        const converter = new RecordConverter({
+            transformName: toCamelCase,
+        });
         converter.convert(`${avroFolder}/ComplexRecord.avsc`);
 
         const actual = converter.joinExports();

--- a/test/components/Converters/RecordConverter.ts
+++ b/test/components/Converters/RecordConverter.ts
@@ -17,7 +17,7 @@ const getExpectedResult = (file: string) => {
 
 describe("RecordType Converter test", () => {
     it("should convert simple avro schema to TS interface", () => {
-        const converter = new RecordConverter();
+        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/SimpleRecord.avsc`);
 
         const actual = converter.joinExports();
@@ -26,7 +26,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert simple avro schema json to TS interface", () => {
-        const converter = new RecordConverter();
+        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
         const avro = JSON.parse(fs.readFileSync(`${avroFolder}/SimpleRecord.json`).toString());
         converter.convert(avro);
 
@@ -36,7 +36,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with interface to TS interface", () => {
-        const converter = new RecordConverter();
+        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/RecordWithInterface.avsc`);
 
         const actual = converter.joinExports();
@@ -45,7 +45,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with MapType type to TS interface", () => {
-        const converter = new RecordConverter();
+        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/RecordWithMap.avsc`);
 
         const actual = converter.joinExports();
@@ -54,7 +54,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with all types to TS interface", () => {
-        const converter = new RecordConverter();
+        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/RecordWithUnion.avsc`);
 
         const actual = converter.joinExports();
@@ -63,7 +63,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with logical types", () => {
-        const converter = new RecordConverter();
+        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/RecordWithLogicalTypes.avsc`);
 
         const actual = converter.joinExports();
@@ -72,7 +72,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with mapped logical types", () => {
-        const converter = new RecordConverter({ "timestamp-millis" : "string" });
+        const converter = new RecordConverter({ "timestamp-millis" : "string" }, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/RecordWithLogicalTypes.avsc`);
 
         const actual = converter.joinExports();
@@ -81,7 +81,7 @@ describe("RecordType Converter test", () => {
     });
 
     it("should convert avro schema with MapType type to TS interface", () => {
-        const converter = new RecordConverter();
+        const converter = new RecordConverter({}, (str) => str.replace(/\./gu, ""));
         converter.convert(`${avroFolder}/ComplexRecord.avsc`);
 
         const actual = converter.joinExports();

--- a/test/data/expected/ComplexRecord.ts.test
+++ b/test/data/expected/ComplexRecord.ts.test
@@ -8,7 +8,7 @@ export interface EmailAddress {
     dateAdded: number;
 }
 
-export interface User {
+export interface comexampleavroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/ComplexRecord.ts.test
+++ b/test/data/expected/ComplexRecord.ts.test
@@ -8,7 +8,7 @@ export interface EmailAddress {
     dateAdded: number;
 }
 
-export interface comexampleavroUser {
+export interface comExampleAvroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithEnum.ts.test
+++ b/test/data/expected/RecordWithEnum.ts.test
@@ -1,4 +1,4 @@
-export interface comexampleavroUser {
+export interface comExampleAvroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithEnum.ts.test
+++ b/test/data/expected/RecordWithEnum.ts.test
@@ -1,4 +1,4 @@
-export interface User {
+export interface comexampleavroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithInterface.ts.test
+++ b/test/data/expected/RecordWithInterface.ts.test
@@ -4,7 +4,7 @@ export interface EmailAddress {
     dateAdded: number;
 }
 
-export interface comexampleavroUser {
+export interface comExampleAvroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithInterface.ts.test
+++ b/test/data/expected/RecordWithInterface.ts.test
@@ -4,7 +4,7 @@ export interface EmailAddress {
     dateAdded: number;
 }
 
-export interface User {
+export interface comexampleavroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithLogicalTypes.ts.test
+++ b/test/data/expected/RecordWithLogicalTypes.ts.test
@@ -1,4 +1,4 @@
-export interface comexampleavroEvent {
+export interface comExampleAvroEvent {
     id: number;
     createdAt: number;
 }

--- a/test/data/expected/RecordWithLogicalTypes.ts.test
+++ b/test/data/expected/RecordWithLogicalTypes.ts.test
@@ -1,4 +1,4 @@
-export interface Event {
+export interface comexampleavroEvent {
     id: number;
     createdAt: number;
 }

--- a/test/data/expected/RecordWithLogicalTypesMapped.ts.test
+++ b/test/data/expected/RecordWithLogicalTypesMapped.ts.test
@@ -1,4 +1,4 @@
-export interface Event {
+export interface comexampleavroEvent {
     id: number;
     createdAt: string;
 }

--- a/test/data/expected/RecordWithLogicalTypesMapped.ts.test
+++ b/test/data/expected/RecordWithLogicalTypesMapped.ts.test
@@ -1,4 +1,4 @@
-export interface comexampleavroEvent {
+export interface comExampleAvroEvent {
     id: number;
-    createdAt: string;
+    createdAt: number;
 }

--- a/test/data/expected/RecordWithMap.ts.test
+++ b/test/data/expected/RecordWithMap.ts.test
@@ -2,7 +2,7 @@ export interface Foo {
     label: string;
 }
 
-export interface comexampleavroUser {
+export interface comExampleAvroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithMap.ts.test
+++ b/test/data/expected/RecordWithMap.ts.test
@@ -2,7 +2,7 @@ export interface Foo {
     label: string;
 }
 
-export interface User {
+export interface comexampleavroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithUnion.ts.test
+++ b/test/data/expected/RecordWithUnion.ts.test
@@ -1,4 +1,4 @@
-export interface comexampleavroUser {
+export interface comExampleAvroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/RecordWithUnion.ts.test
+++ b/test/data/expected/RecordWithUnion.ts.test
@@ -1,4 +1,4 @@
-export interface User {
+export interface comexampleavroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/SimpleRecord.ts.test
+++ b/test/data/expected/SimpleRecord.ts.test
@@ -1,4 +1,4 @@
-export interface comexampleavroUser {
+export interface comExampleAvroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/SimpleRecord.ts.test
+++ b/test/data/expected/SimpleRecord.ts.test
@@ -1,4 +1,4 @@
-export interface User {
+export interface comexampleavroUser {
     id: number;
     username: string;
     passwordHash: string;

--- a/test/data/expected/TradeCollection.ts.test
+++ b/test/data/expected/TradeCollection.ts.test
@@ -13,16 +13,16 @@ export interface Trade {
     side?: null | TradeDirection;
 }
 
-export interface TradeCollectionInterface {
+export interface comexampleavroTradeCollectionInterface {
     producerId: string;
     exchange: string;
     market: string;
     trades: Trade[];
 }
 
-export class TradeCollection extends BaseAvroRecord implements TradeCollectionInterface {
+export class comexampleavroTradeCollection extends BaseAvroRecord implements comexampleavroTradeCollectionInterface {
 
-    public static readonly subject: string = "TradeCollection";
+    public static readonly subject: string = "comexampleavroTradeCollection";
     public static readonly schema: object = {
     "type": "record",
     "name": "TradeCollection",
@@ -114,8 +114,8 @@ export class TradeCollection extends BaseAvroRecord implements TradeCollectionIn
     ]
 }
 
-    public static deserialize(buffer: Buffer, newSchema?: object): TradeCollection {
-        const result = new TradeCollection();
+    public static deserialize(buffer: Buffer, newSchema?: object): comexampleavroTradeCollection {
+        const result = new comexampleavroTradeCollection();
         const rawResult = this.internalDeserialize(buffer, newSchema);
         result.loadValuesFromType(rawResult);
 
@@ -128,10 +128,10 @@ export class TradeCollection extends BaseAvroRecord implements TradeCollectionIn
     public trades: Trade[] = [];
 
     public schema(): object {
-        return TradeCollection.schema;
+        return comexampleavroTradeCollection.schema;
     }
 
     public subject(): string {
-        return TradeCollection.subject;
+        return comexampleavroTradeCollection.subject;
     }
 }

--- a/test/data/expected/TradeCollection.ts.test
+++ b/test/data/expected/TradeCollection.ts.test
@@ -13,16 +13,16 @@ export interface Trade {
     side?: null | TradeDirection;
 }
 
-export interface comexampleavroTradeCollectionInterface {
+export interface comExampleAvroTradeCollectionInterface {
     producerId: string;
     exchange: string;
     market: string;
     trades: Trade[];
 }
 
-export class comexampleavroTradeCollection extends BaseAvroRecord implements comexampleavroTradeCollectionInterface {
+export class comExampleAvroTradeCollection extends BaseAvroRecord implements comExampleAvroTradeCollectionInterface {
 
-    public static readonly subject: string = "comexampleavroTradeCollection";
+    public static readonly subject: string = "comExampleAvroTradeCollection";
     public static readonly schema: object = {
     "type": "record",
     "name": "TradeCollection",
@@ -114,8 +114,8 @@ export class comexampleavroTradeCollection extends BaseAvroRecord implements com
     ]
 }
 
-    public static deserialize(buffer: Buffer, newSchema?: object): comexampleavroTradeCollection {
-        const result = new comexampleavroTradeCollection();
+    public static deserialize(buffer: Buffer, newSchema?: object): comExampleAvroTradeCollection {
+        const result = new comExampleAvroTradeCollection();
         const rawResult = this.internalDeserialize(buffer, newSchema);
         result.loadValuesFromType(rawResult);
 
@@ -128,10 +128,10 @@ export class comexampleavroTradeCollection extends BaseAvroRecord implements com
     public trades: Trade[] = [];
 
     public schema(): object {
-        return comexampleavroTradeCollection.schema;
+        return comExampleAvroTradeCollection.schema;
     }
 
     public subject(): string {
-        return comexampleavroTradeCollection.subject;
+        return comExampleAvroTradeCollection.subject;
     }
 }

--- a/test/data/expected/User.ts.test
+++ b/test/data/expected/User.ts.test
@@ -27,7 +27,7 @@ export interface ToDoItem {
     subItems: any[];
 }
 
-export interface UserInterface {
+export interface comExampleAvroUserInterface {
     id: number;
     username: string;
     passwordHash: string;
@@ -37,9 +37,9 @@ export interface UserInterface {
     toDoItems: ToDoItem[];
 }
 
-export class User extends BaseAvroRecord implements UserInterface {
+export class comExampleAvroUser extends BaseAvroRecord implements comExampleAvroUserInterface {
 
-    public static readonly subject: string = "User";
+    public static readonly subject: string = "comExampleAvroUser";
     public static readonly schema: object = {
     "type": "record",
     "name": "User",
@@ -224,8 +224,8 @@ export class User extends BaseAvroRecord implements UserInterface {
     ]
 }
 
-    public static deserialize(buffer: Buffer, newSchema?: object): User {
-        const result = new User();
+    public static deserialize(buffer: Buffer, newSchema?: object): comExampleAvroUser {
+        const result = new comExampleAvroUser();
         const rawResult = this.internalDeserialize(buffer, newSchema);
         result.loadValuesFromType(rawResult);
 
@@ -241,10 +241,10 @@ export class User extends BaseAvroRecord implements UserInterface {
     public toDoItems!: ToDoItem[];
 
     public schema(): object {
-        return User.schema;
+        return comExampleAvroUser.schema;
     }
 
     public subject(): string {
-        return User.subject;
+        return comExampleAvroUser.subject;
     }
 }


### PR DESCRIPTION
supports `transformName` option when creating `Compiler` instance.
the transformName function should take a string and return a string and will be called on every `record` name if present